### PR TITLE
Add simple AR photobooth example

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
         "dev": "node ./node_modules/tsx/dist/cli.cjs ./src/index.ts",
         "build": "node ./node_modules/rollup/dist/bin/rollup -c",
         "start": "node dist/index.js",
-        "selfie": "node ./node_modules/tsx/dist/cli.cjs ./src/selfie-mirror/main.ts"
+        "selfie": "node ./node_modules/tsx/dist/cli.cjs ./src/selfie-mirror/main.ts",
+        "photobooth": "node ./node_modules/tsx/dist/cli.cjs ./src/photobooth/server.ts"
     },
     "keywords": [],
     "dependencies": {

--- a/public/photobooth/index.html
+++ b/public/photobooth/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>AR Photobooth</title>
+  <style>
+    body { margin:0; overflow:hidden; }
+    video, canvas { position:absolute; top:0; left:0; }
+  </style>
+</head>
+<body>
+  <video id="video" width="640" height="480" autoplay muted playsinline></video>
+  <canvas id="overlay" width="640" height="480"></canvas>
+
+  <script defer src="https://cdn.jsdelivr.net/npm/face-api.js@0.22.2/dist/face-api.min.js"></script>
+  <script defer src="script.js"></script>
+</body>
+</html>

--- a/public/photobooth/script.js
+++ b/public/photobooth/script.js
@@ -1,0 +1,35 @@
+async function loadModels() {
+  const MODEL_URL = 'https://cdn.jsdelivr.net/npm/face-api.js@0.22.2/weights'
+  await faceapi.nets.tinyFaceDetector.loadFromUri(MODEL_URL)
+  await faceapi.nets.faceLandmark68Net.loadFromUri(MODEL_URL)
+}
+
+async function start() {
+  await loadModels()
+  const video = document.getElementById('video')
+  const stream = await navigator.mediaDevices.getUserMedia({ video: {} })
+  video.srcObject = stream
+  video.addEventListener('playing', () => onPlay(video))
+}
+
+async function onPlay(video) {
+  const canvas = document.getElementById('overlay')
+  const ctx = canvas.getContext('2d')
+  const displaySize = { width: video.width, height: video.height }
+  faceapi.matchDimensions(canvas, displaySize)
+  setInterval(async () => {
+    const detections = await faceapi
+      .detectAllFaces(video, new faceapi.TinyFaceDetectorOptions())
+      .withFaceLandmarks()
+    ctx.clearRect(0, 0, canvas.width, canvas.height)
+    if (detections.length > 0) {
+      const nose = detections[0].landmarks.getNose()[3]
+      ctx.fillStyle = 'rgba(255,0,0,0.5)'
+      ctx.beginPath()
+      ctx.arc(nose.x, nose.y, 30, 0, Math.PI * 2)
+      ctx.fill()
+    }
+  }, 100)
+}
+
+start()

--- a/src/photobooth/server.ts
+++ b/src/photobooth/server.ts
@@ -1,0 +1,12 @@
+import express from 'express'
+import path from 'path'
+
+const app = express()
+const PORT = process.env.PORT || 3000
+
+const publicDir = path.join(__dirname, '../../public/photobooth')
+app.use(express.static(publicDir))
+
+app.listen(PORT, () => {
+  console.log(`Photobooth running on http://localhost:${PORT}`)
+})


### PR DESCRIPTION
## Summary
- add static AR photobooth page using face-api.js to overlay a nose mask
- create express server and npm script to launch photobooth

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6898f506066c8324b4431c17cf045942